### PR TITLE
Add qc to snakemake

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ snakemake -s qc/Snakefile all_qc_analysis
 
 The results will be placed in the `plots` directory.
 
+To generate a `tsv` file of QC metrics per sample:
+```
+snakemake -s qc/Snakefile all_qc_summary
+```
+
 ## Credit and Acknowledgements
 
 The tree-with-SNPs plot was inspired by a plot shared by Mads Albertsen.

--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,4 @@ dependencies:
       - dendropy>=4.4.0
       - git+https://github.com/hCoV-2019/lineages.git
       - git+https://github.com/hCoV-2019/pangolin.git
+      - git+https://github.com/rdeborja/ncov_parser.git

--- a/qc/Snakefile
+++ b/qc/Snakefile
@@ -94,6 +94,10 @@ rule all_qc_analysis:
     input:
         get_qc_analysis_plots
 
+rule qc_summary_all:
+    input:
+        "qc_sequencing/summary_qc.tsv"
+
 #
 # generate coverage QC data using bedtools
 #
@@ -289,3 +293,26 @@ rule make_qc_tree_snps:
         plot_script = srcdir("../tree/plot_tree_snps.R")
     shell:
         "Rscript {params.plot_script} qc_analysis {wildcards.prefix}"
+
+# generate the summary QC metrics
+rule make_sample_qc_summary:
+    input:
+        samplecoverage="qc_sequencing/{sample}.per_base_coverage.bed",
+        samplevariants="data/{sample}.variants.tsv",
+        sampleqc="data/{sample}.qc.csv"
+    output:
+        "qc_sequencing/{sample}.summary.qc.tsv"
+    params:
+        py_script="get_qc_summary.py"
+    shell:
+        "{params.py_script} --variants {input.samplevariants} --qc {input.sampleqc} --coverage {input.samplecoverage} > {output}"
+
+rule make_full_qc_summary:
+    input:
+        expand("qc_sequencing/{s}.summary.qc.tsv", s=get_sample_names())
+    output:
+        "qc_sequencing/summary_qc.tsv"
+    params:
+        py_script="collect_qc_summary.py"
+    shell:
+        "{params.py_script} --path qc_sequencing > {output}"

--- a/qc/Snakefile
+++ b/qc/Snakefile
@@ -94,7 +94,7 @@ rule all_qc_analysis:
     input:
         get_qc_analysis_plots
 
-rule qc_summary_all:
+rule all_qc_summary:
     input:
         "qc_sequencing/summary_qc.tsv"
 


### PR DESCRIPTION
Added the QC summary metrics file generation to the main pipeline. Requires the use of ncov_parser which has been included in the environment.yml file.
