### PR TITLE
Fix amplicon heatmap dependency

### DIFF
--- a/qc/Snakefile
+++ b/qc/Snakefile
@@ -254,7 +254,7 @@ rule make_lineage_assignments:
 #
 rule make_qc_plot_amplicon_coverage_heatmap:
     input:
-        expand("qc_sequencing/{s}.per_base_coverage.bed", s=get_sample_names())
+        expand("qc_sequencing/{s}.amplicon_coverage.bed", s=get_sample_names())
     output:
         "plots/{prefix}_amplicon_coverage_heatmap.pdf"
     params:


### PR DESCRIPTION
Fixed a bug where the rule make_qc_plot_amplicon_coverage_heatmap required .per_base_coverage.bed files but actually uses the .amplicon_coverage.bed as input.