### PR TITLE
Update environment for pangolin compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,9 +18,13 @@ dependencies:
   - samtools
   - newick_utils
   - pip=19.3.1
+  - minimap2
+  - numpy=1.19.1
   - biopython
   - pip:
       - dendropy>=4.4.0
       - git+https://github.com/hCoV-2019/lineages.git
       - git+https://github.com/hCoV-2019/pangolin.git
       - git+https://github.com/rdeborja/ncov_parser.git
+      - git+https://github.com/cov-lineages/pangoLEARN.git
+      - git+https://github.com/cov-ert/datafunk.git


### PR DESCRIPTION
Updated environment to keep up with updates to pangolin (adapted to using pangoLEARN). 

Legacy flags do exist for pangolin (`--legacy`); however, when running ncov-tools with SIGNAL, the overall tool is faster with pangolin's changes. 

`pangolin --legacy` requires pangoLEARN nonetheless or else you get a ImportError.