### PR TITLE
pinned biopython to version 1.77

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - minimap2
   - poppler
   - numpy=1.19.1
-  - biopython
+  - biopython=1.77
   - texlive-core
   - pip:
       - dendropy>=4.4.0


### PR DESCRIPTION
As suggested by @dfornika pinning version 1.77 to Biopython due to removed support for `Bio.Alphabet`