### PR TITLE
Fix conda package name for parasail

### DIFF
--- a/workflow/envs/environment.yml
+++ b/workflow/envs/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - r-ggforce=0.3.1
   - bedtools
   - samtools
-  - parasail
+  - parasail-python
   - newick_utils
   - pip=19.3.1
   - minimap2


### PR DESCRIPTION
Fixes #57 

The conda package name for parasail is [parasail-python](https://anaconda.org/bioconda/parasail-python)