### PR TITLE
removed -lv flag from pangolin which has been deprecated

### DIFF
--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -87,7 +87,7 @@ rule make_pangolin_version:
     output:
         "lineages/{prefix}_pangolin_version.txt"
     shell:
-        "pangolin -v > {output}; pangolin -lv >> {output}; pangolin -pv >> {output}"
+        "pangolin -v > {output}; pangolin -pv >> {output}"
 
 
 # get a file containing the path to the variants tsv/vcfs for all samples


### PR DESCRIPTION
in response to issue #65, removed -lv command from pangolin output