### PR TITLE
snpEff database build support for different version

### DIFF
--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -41,6 +41,14 @@ def get_recurrent_heatmap_plot(wildcards):
     out = "plots/%s_aa_mutation_heatmap.pdf" % (prefix)
     return out
 
+def get_snpeff_dirs():
+    snpeff_dirs = list()
+    for snpeff_dir in os.scandir('/'.join([os.environ['CONDA_PREFIX'], 'share'])):
+        if snpeff_dir.name.startswith('snpeff'):
+            snpeff_dirs.append(snpeff_dir.name)
+    return snpeff_dirs
+
+
 #
 # Rules for annotating variants with functional consequence
 #
@@ -50,11 +58,13 @@ rule all_qc_annotation:
 
 rule build_snpeff_db:
     input:
-        expand(os.environ['CONDA_PREFIX'] + '/share/snpeff-5.0-0/data/MN908947.3/snpEffectPredictor.bin')
+        expand(os.environ['CONDA_PREFIX'] + '/share/{snpeff_dir}/data/MN908947.3/snpEffectPredictor.bin', snpeff_dir=get_snpeff_dirs())
 
 rule download_db_files:
+    input:
+        expand(os.environ['CONDA_PREFIX'] + '/share/{snpeff_dir}', snpeff_dir=get_snpeff_dirs())
     output:
-        expand(os.environ['CONDA_PREFIX'] + '/share/snpeff-5.0-0/data/MN908947.3/snpEffectPredictor.bin')
+        expand(os.environ['CONDA_PREFIX'] + '/share/{snpeff_dir}/data/MN908947.3/snpEffectPredictor.bin', snpeff_dir=get_snpeff_dirs())
     params:
         script=srcdir("../scripts/build_db.py")
     shell:

--- a/workflow/scripts/build_db.py
+++ b/workflow/scripts/build_db.py
@@ -6,15 +6,16 @@ A small workaround for building the MN908947.3 database in snpeff.
 
 import os
 
-SNPEFF_PREFIX = 'snpeff-5.0-0'
+snpeff_dir_prefix = 'snpeff'
 
 def main():
     """
     Main function to run shell commands to build the MN908947.3 snpEff database
     """
-    snpeff_dir = '/'.join([os.environ['CONDA_PREFIX'], 'share', SNPEFF_PREFIX])
-    os.chdir(snpeff_dir)
-    os.system('./scripts/buildDbNcbi.sh MN908947.3')
+    for dir_name in os.scandir('/'.join([os.environ['CONDA_PREFIX'], 'share'])):
+        if dir_name.name.startswith(snpeff_dir_prefix):
+            os.chdir('/'.join([os.environ['CONDA_PREFIX'], 'share', dir_name.name]))
+            os.system(f'{"/".join([os.environ["CONDA_PREFIX"], "share", dir_name.name, "scripts/buildDbNcbi.sh"])} MN908947.3')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removed hardcoded version of snpEff from scripts and workflows, added support for multiple versions of snpEff in a single conda environment