### PR TITLE
Add configurable optional output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ completeness_threshold: 0.9
 # or the path to a local VCF file. 
 # Built in lists: https://github.com/jts/ncov-watch/tree/master/ncov_watch/watchlists
 mutation_set: spike_mutations
+
+# user specifiable output directory 
+# defaults to just current working directory but otherwise
+# will write output files to the specified directory
+output_directory: run1_output
 ```
 
 ## Running

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,9 +1,21 @@
 #
 # Helper functions and rules
 #
+from pathlib import Path
+
 include: "defaults.smk"
 
 configfile: "config.yaml"
+
+# to handle custom output directories make input paths in config absolute
+# paths then assign snakemake workdir to the specified config workdir
+# as data_root is built into the remaining input paths
+if 'output_directory' in config:
+    for input_path_config in ['data_root', 'primer_bed', 'reference_genome', 'tree_include_consensus']:
+        if input_path_config in config:
+            config[input_path_config] = str(Path(config[input_path_config]).absolute())
+    workdir: config['output_directory']
+
 
 def get_sample_names():
 


### PR DESCRIPTION
Add an optional `output_dir` value that specifies a directory to output results into.

To ensure that relative paths to input files/resources in `config.yaml` are still valid when `output_dir` is specified, the relevant values are resolved to absolute paths if present in the `config.yaml`.

If `output_dir` isn't specified then the `output_dir`/workdir is just the directory that snakemake is executed from i.e., the current working directory will be used (as is the current behaviour) and no other changes are made.

Changes have been tested for `conda` env install.