### PR TITLE
added creation of primer snp depth summary as part of all rule

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -14,4 +14,5 @@ rule all:
         get_qc_sequencing_plots,
         get_qc_analysis_plots,
         get_qc_reports,
-        get_recurrent_heatmap_plot
+        get_recurrent_heatmap_plot,
+        get_primer_snp_depth_table


### PR DESCRIPTION
primer_snp_depth_summary.tsv file is created when "all" rule is invoked