### PR TITLE
Create alleles from vcf

### DIFF
--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -68,6 +68,18 @@ rule make_alleles:
     shell:
         "python {params.alleles_script} --reference-name MN908947.3 {input} > {output}"
 
+# parse the data directory and create the alleles file from sample VCFs
+rule make_alleles_vcf:
+    input:
+        get_data_directory
+    output:
+        "qc_analysis/{prefix}_alleles_vcf.tsv"
+    params:
+        script="/.mounts/labs/simpsonlab/projects/ncov/code/ncov-tools/workflow/scripts/vcf2alleles.py",
+        pattern=get_variant_format_pattern
+    shell:
+        "python {params.script} --path {input} --pattern {params.pattern} > {output}"
+
 # assign lineages to the consensus genomes using pangolin
 rule make_lineage_assignments:
     input:

--- a/workflow/rules/defaults.smk
+++ b/workflow/rules/defaults.smk
@@ -1,6 +1,7 @@
 #
 # Wrapper for accessing the config, with sensible defaults
 #
+import re
 
 #
 def get_bam_pattern():
@@ -60,3 +61,14 @@ def get_watch_mutation_set(wildcards):
 #
 def get_voc_pango_lineages(wildcards):
     return config.get("voc_pango_lineages", "B.1.1.7,B.1.351,P.1,B.1.617.2")
+
+#
+def get_data_directory(wildcards=None):
+    return config["data_root"]
+
+#
+def get_variant_format_pattern(wildcards=None):
+    variant_format_pattern = config['variants_pattern']
+    _pattern = re.sub('{data_root}/{sample}', '', variant_format_pattern)
+    return _pattern
+

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -41,7 +41,7 @@ rule make_negative_control_report:
 rule make_mixture_report:
     input:
         fpileups="qc_sequencing/{prefix}_fpileups.fofn",
-        alleles="qc_analysis/{prefix}_alleles.tsv"
+        alleles="qc_analysis/{prefix}_alleles_vcf.tsv"
     output:
         "qc_reports/{prefix}_mixture_report.tsv"
     params:

--- a/workflow/scripts/vcf2alleles.py
+++ b/workflow/scripts/vcf2alleles.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+
+from ncov.parser.Vcf import *
+import argparse
+import os
+import sys
+import re
+
+
+def init_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--path', required=True,
+                        help='path containing VCF files to process')
+    parser.add_argument('-t', '--pattern', default='.variants.norm.vcf',
+                        help='the VCF file pattern [default: .variants.norm.vcf]')
+    return parser.parse_args()
+
+def create_default_sample(name, pos, ref, alt):
+    return {'samples' : [{'name' : name, 'pos': pos, 'ref': ref, 'alt': alt}]}
+
+
+def get_sample_name(file, pattern):
+    return re.sub(pattern, '', file)
+
+
+def write_alleles_line(row):
+    """
+    Write out sample mutation as follows:
+    * name
+    * pos
+    * ref_allele
+    * alt_allele
+    * samples_with_allele
+    """
+    samples_with_alleles = len(row['samples']) - 1
+    for sample in row['samples']:
+        if samples_with_alleles < 1:
+            continue
+        elif len(str(sample['ref'])) > 1 or len(str(sample['alt'])) > 1:
+            continue
+        else:
+            print('\t'.join([str(sample['name']),
+                             str(sample['pos']),
+                             str(sample['ref']),
+                             str(sample['alt']),
+                             str(samples_with_alleles)]))
+
+
+def main():
+    args = init_args()
+    var_dict = dict()
+    for file in os.listdir(args.path):
+        if file.endswith(args.pattern):
+            vcf_reader = vcf.Reader(filename='/'.join([args.path, file]))
+            for var in vcf_reader:
+                var_id = create_vcf_variant_id(var=var)
+                if var_id not in var_dict:
+                    var_dict[var_id] = create_default_sample(name=get_sample_name(file=file, pattern=args.pattern), pos=var.POS, ref=var.REF, alt=var.ALT[0])
+                elif var_id in var_dict:
+                    var_dict[var_id]['samples'].append({'name': get_sample_name(file=file, pattern=args.pattern), "pos": var.POS, "ref": var.REF, "alt": var.ALT[0]})
+    print('\t'.join(['name', 'pos', 'ref_allele', 'alt_allele', 'samples_with_allele']))
+    for item in var_dict:
+        write_alleles_line(var_dict[item])
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Added an `alleles_vcf.tsv` file which constructs the alleles file based on the VCF mutations across all samples.  The mixture report has been updated to use the `alleles_vcf.tsv` file for the `mixture_report.tsv`.
