### PR TITLE
Remove config amplicon prefix when creating negative control report

### DIFF
--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -33,9 +33,10 @@ rule make_negative_control_report:
     output:
         "qc_reports/{prefix}_negative_control_report.tsv"
     params:
-        script=srcdir("../scripts/negative_control_check.py")
+        script=srcdir("../scripts/negative_control_check.py"),
+        primer_prefix=get_primer_prefix
     shell:
-        "python {params.script} {input.bed} > {output}"
+        "python {params.script} --primer_prefix {params.primer_prefix} {input.bed} > {output}"
 
 # detect possible contaimination or mixtures of samples based on allele frequencies
 rule make_mixture_report:

--- a/workflow/scripts/negative_control_check.py
+++ b/workflow/scripts/negative_control_check.py
@@ -2,6 +2,7 @@ import argparse
 import pysam
 import sys
 import csv
+import re
 import os
 
 class RegionCoverage:
@@ -27,6 +28,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--max-coverage', type=int, default=5)
 parser.add_argument('--max-amplicon-coverage', type=int, default=20)
 parser.add_argument('--max-amplicon-fraction', type=int, default=0.5)
+parser.add_argument('--primer_prefix', type=str, default="nCoV-2019")
 args, files = parser.parse_known_args()
 
 
@@ -41,7 +43,7 @@ for fn in files:
         for row in reader:
             position = int(row["start"]) + int(row["position"])
             depth = int(row["depth"])
-            amplicon_id = int(row["amplicon_id"].split("_")[1])
+            amplicon_id = int(re.sub("[^0-9]", '', row["amplicon_id"].lstrip(args.primer_prefix)))
 
             #
             genome_coverage.update(position, depth)


### PR DESCRIPTION
Just adding using the `amplicon_prefix` var in the `negative_control_check.py` script as a new scheme with multiple "_" was throwing an error when trying to strip down to just the amplicon number.