### PR TITLE
Update conda environment for Pangolin v4.0+

### DIFF
--- a/workflow/envs/environment.yml
+++ b/workflow/envs/environment.yml
@@ -34,8 +34,7 @@ dependencies:
       - ncov-parser
       - git+https://github.com/hCoV-2019/lineages.git
       - git+https://github.com/hCoV-2019/pangolin.git
-      - git+https://github.com/cov-lineages/pangoLEARN.git
       - git+https://github.com/cov-lineages/constellations.git
       - git+https://github.com/cov-lineages/scorpio.git
-      - git+https://github.com/cov-lineages/pango-designation.git
+      - git+https://github.com/cov-lineages/pangolin-data.git
       - git+https://github.com/jts/ncov-watch.git


### PR DESCRIPTION
`pangolin-data` aims to replace the `pangoLEARN` and `pango-designation` requirements come Pangolin v4.0 onwards. This is assuming you only intend to run the latest Pangolin version. The previous environments will still be needed otherwise for past versions which seem to be phasing out. 