### PR TITLE
Add pangolin analysis mode option

### DIFF
--- a/workflow/rules/analysis.smk
+++ b/workflow/rules/analysis.smk
@@ -74,9 +74,11 @@ rule make_lineage_assignments:
         "qc_analysis/{prefix}_consensus.fasta"
     output:
         "lineages/{prefix}_lineage_report.csv"
+    params:
+        pango_analysis_mode=get_pangolin_analysis_mode
     threads: workflow.cores
     shell:
-        "pangolin --outfile {output} {input}"
+        "pangolin --outfile {output} --analysis-mode {params.pango_analysis_mode} {input}"
 
 # write pangolin version information to a file
 # this depends on the pangolin output file to

--- a/workflow/rules/defaults.smk
+++ b/workflow/rules/defaults.smk
@@ -62,5 +62,9 @@ def get_watch_mutation_set(wildcards):
     return config.get("mutation_set", "spike_mutations")
 
 #
+def get_pangolin_analysis_mode(wildcards):
+    return config.get("pango_analysis_mode", "accurate")
+
+#
 def get_voc_pango_lineages(wildcards):
     return config.get("voc_pango_lineages", "B.1.1.7,B.1.351,P.1,B.1.617.2")


### PR DESCRIPTION
Was looking to change the pangolin analysis type while running ncov-tools and I didn't see any configuration options for it so I've attempted to add it in with my limited snakemake knowledge.

Pangolin 4 lets the user specify an analysis mode from "fast" or "accurate" with the `--analysis-mode` argument. This change is adding that in with the default set to "accurate" as is the same with the tool itself.

I am not sure how this affects the `pangolin_version: "3"` option so it might need a few changes to accommodate the backwards compatibility aspect there

Cheers