### PR TITLE
Fix bug for primer prefixes containing numbers

### DIFF
--- a/workflow/scripts/negative_control_check.py
+++ b/workflow/scripts/negative_control_check.py
@@ -43,7 +43,7 @@ for fn in files:
         for row in reader:
             position = int(row["start"]) + int(row["position"])
             depth = int(row["depth"])
-            amplicon_id = int(re.sub("[^0-9]", '', row["amplicon_id"].lstrip(args.primer_prefix)))
+            amplicon_id = int(re.sub("[^0-9]", '', row["amplicon_id"].replace(args.primer_prefix, '')))
 
             #
             genome_coverage.update(position, depth)


### PR DESCRIPTION
If the primer prefix contains a number (e.g., midnightv2_) then strip in the negative control command can remove matching amplicon numbers:

 `"midnightv2_2".strip("midnightv2") == "_"` using replace makes this more specific and less prone to issues.