### PR TITLE
Check for empty merged dataframe before plotting

### DIFF
--- a/workflow/scripts/plot/plot_qc_sequencing.R
+++ b/workflow/scripts/plot/plot_qc_sequencing.R
@@ -3,7 +3,10 @@ plot_depth_by_amplicon_and_ct <- function(df, metadata, outname)
 {
     # merge df with metadata
     merged = dplyr::inner_join(df, metadata, by = "sample")
-
+    if (nrow(merged) < 1) {
+      ggsave(outname, width=15, height=10)
+      quit()
+    }
     ggplot(merged, aes(x=ct, y=mean_depth)) +
         geom_point() +
         scale_y_log10() +


### PR DESCRIPTION
Proposed fix for #108 

There may be other ways to handle this but here's one option. If the merged dataframe is empty, write an empty plot (so the snakemake pipeline won't crash due to a missing input) and exit.